### PR TITLE
Update ConvertExtensions.cs

### DIFF
--- a/VagabondK/ConvertExtensions.cs
+++ b/VagabondK/ConvertExtensions.cs
@@ -19,7 +19,9 @@
             
             try
             {
-                return (T)Convert.ChangeType(value, typeof(T));
+                Type t = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+                
+                return (T)Convert.ChangeType(value, t);
             }
             catch
             {


### PR DESCRIPTION
T가 Nullable 타입 일 경우, Convert.ChangeType으로 형 변환 시 실패(return Null) 합니다.
https://stackoverflow.com/questions/3531318/convert-changetype-fails-on-nullable-types

Nullable.GetUnderlyingType으로 Nullable 형식 인수를 확인할 수 있습니다.
https://docs.microsoft.com/ko-kr/dotnet/api/system.nullable.getunderlyingtype?view=net-6.0